### PR TITLE
Fix: filtering plugins by category

### DIFF
--- a/spa/src/components/CategoryTag.vue
+++ b/spa/src/components/CategoryTag.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import type { PluginCategory } from '@/api/pluginsApi.ts'
+import type { Tag } from '@/components/FilterTags.vue'
+
 const props = defineProps<{
   label: string
   value: string
@@ -6,11 +9,11 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'click', value: string): void
+  (e: 'click', value: Tag | PluginCategory): void
 }>()
 
 function handleClick() {
-  emit('click', props.value)
+  emit('click', {value: props.value, label: props.label})
 }
 
 function handleKeydown(event: KeyboardEvent) {

--- a/spa/src/components/FilterTags.vue
+++ b/spa/src/components/FilterTags.vue
@@ -21,7 +21,7 @@
           :key="getTagValue(tag)"
           :label="getTagLabel(tag)"
           :value="getTagValue(tag)"
-          :is-active="activeTags.includes(tag)"
+          :is-active="!!activeTags.filter(t => t.value === tag.value).length"
           @click="handleTagClick"
         />
       </div>

--- a/spa/src/components/FilterTags.vue
+++ b/spa/src/components/FilterTags.vue
@@ -18,9 +18,9 @@
       <div class="flex flex-wrap gap-2">
         <CategoryTag
           v-for="tag in tags"
-          :key="tag"
+          :key="getTagValue(tag)"
           :label="getTagLabel(tag)"
-          :value="tag"
+          :value="getTagValue(tag)"
           :is-active="activeTags.includes(tag)"
           @click="handleTagClick"
         />
@@ -43,15 +43,16 @@
 
 <script setup lang="ts">
 import CategoryTag from './CategoryTag.vue'
+import type { PluginCategory } from '@/api/pluginsApi.ts'
 
-interface Tag {
+export interface Tag {
   value: string
-  label?: string
+  label: string
 }
 
 interface Props {
-  tags: string[] | Tag[]
-  activeTags: string[]
+  tags: PluginCategory[] | Tag[]
+  activeTags: PluginCategory[] | Tag[]
   title?: string
   showClearButton?: boolean
   showEmptyState?: boolean
@@ -61,7 +62,7 @@ interface Props {
 }
 
 interface Emits {
-  (e: 'toggle', value: string): void
+  (e: 'toggle', value: Tag | PluginCategory): void
   (e: 'clearAll'): void
 }
 
@@ -76,21 +77,15 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>()
 
-function getTagLabel(tag: string | Tag): string {
-  if (typeof tag === 'string') {
-    return tag
-  }
+function getTagLabel(tag: Tag | PluginCategory): string {
   return tag.label || tag.value
 }
 
-function getTagValue(tag: string | Tag): string {
-  if (typeof tag === 'string') {
-    return tag
-  }
+function getTagValue(tag: Tag | PluginCategory): string {
   return tag.value
 }
 
-function handleTagClick(value: string) {
+function handleTagClick(value: Tag | PluginCategory): void {
   emit('toggle', value)
 }
 </script>

--- a/spa/src/components/FilterTags.vue
+++ b/spa/src/components/FilterTags.vue
@@ -21,7 +21,7 @@
           :key="getTagValue(tag)"
           :label="getTagLabel(tag)"
           :value="getTagValue(tag)"
-          :is-active="!!activeTags.filter(t => t.value === tag.value).length"
+          :is-active="activeTags.some(t => t.value === tag.value)"
           @click="handleTagClick"
         />
       </div>

--- a/spa/src/components/SearchAndFilters.vue
+++ b/spa/src/components/SearchAndFilters.vue
@@ -64,7 +64,7 @@
           <span class="font-medium text-white">Active filters:</span>
           <div class="flex flex-wrap gap-2">
             <span v-if="activeCategories?.length" class="bg-slate-700/60 px-2 py-1 rounded text-xs">
-              {{ categoriesLabel }}: {{ activeCategories.join(', ') }}
+              {{ categoriesLabel }}: {{ activeCategoriesLabel }}
             </span>
             <span v-if="searchQuery" class="bg-slate-700/60 px-2 py-1 rounded text-xs">
               Search: "{{ searchQuery }}"
@@ -94,11 +94,13 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { PluginCategory } from '@/api/pluginsApi.ts'
+import type { Tag } from '@/components/FilterTags.vue'
 
 interface Props {
   searchQuery: string
   sourceFilter?: 'all' | 'official' | 'community'
-  activeCategories?: string[]
+  activeCategories?: PluginCategory[] | Tag[]
   searchPlaceholder?: string
   showSourceFilter?: boolean
   showActiveFilters?: boolean
@@ -134,6 +136,12 @@ const hasActiveFilters = computed(() => {
     props.searchQuery ||
     props.sourceFilter !== 'all'
   )
+})
+
+const activeCategoriesLabel = computed(() => {
+  return props.activeCategories
+    .map(c => c.label)
+    .join(', ')
 })
 </script>
 

--- a/spa/src/views/PluginsList.vue
+++ b/spa/src/views/PluginsList.vue
@@ -7,15 +7,16 @@ import ErrorAlert from '@/components/ErrorAlert.vue'
 
 // New modular components
 import SearchAndFilters from '@/components/SearchAndFilters.vue'
-import FilterTags from '@/components/FilterTags.vue'
+import FilterTags, { type Tag } from '@/components/FilterTags.vue'
 import SelectionSummary from '@/components/SelectionSummary.vue'
 import LoadingState from '@/components/LoadingState.vue'
 import EmptyState from '@/components/EmptyState.vue'
 import ConfigurationGeneration from '@/components/ConfigurationGeneration.vue'
 import SelectionConfirmationModal from '@/components/SelectionConfirmationModal.vue'
+import type { PluginCategory } from '@/api/pluginsApi.ts'
 
 const pluginStore = usePluginsStore()
-const activeCategories = ref<string[]>([])
+const activeCategories = ref<PluginCategory[] | Tag[]>([])
 const configFormat = ref<'toml' | 'json' | 'docker' | 'dockerfile'>('toml')
 
 const searchQuery = ref('')
@@ -41,7 +42,7 @@ const filteredPlugins = computed(() => {
   return pluginStore.pluginsWithSelection.filter((p) => {
     const categoryMatch =
       activeCategories.value.length === 0 ||
-      (p.category && activeCategories.value.includes(p.category))
+      (p.category && activeCategories.value.filter(c => c.value === p.category).length)
     const sourceMatch =
       sourceFilter.value === 'all' ||
       (sourceFilter.value === 'official' && p.is_official) ||
@@ -64,10 +65,10 @@ const selectionSummary = computed(() => {
 })
 
 // Filter management
-function toggleCategory(value: string) {
-  const index = activeCategories.value.indexOf(value)
+function toggleCategory(category: PluginCategory) {
+  const index = activeCategories.value.findIndex(c => c.value === category.value)
   if (index === -1) {
-    activeCategories.value.push(value)
+    activeCategories.value.push(category)
   } else {
     activeCategories.value.splice(index, 1)
   }

--- a/spa/src/views/PluginsList.vue
+++ b/spa/src/views/PluginsList.vue
@@ -42,7 +42,7 @@ const filteredPlugins = computed(() => {
   return pluginStore.pluginsWithSelection.filter((p) => {
     const categoryMatch =
       activeCategories.value.length === 0 ||
-      (p.category && activeCategories.value.filter(c => c.value === p.category).length)
+      (p.category && activeCategories.value.some(c => c.value === p.category))
     const sourceMatch =
       sourceFilter.value === 'all' ||
       (sourceFilter.value === 'official' && p.is_official) ||

--- a/spa/src/views/PresetsList.vue
+++ b/spa/src/views/PresetsList.vue
@@ -7,7 +7,7 @@ import ErrorAlert from '@/components/ErrorAlert.vue'
 
 // New modular components
 import SearchAndFilters from '@/components/SearchAndFilters.vue'
-import FilterTags from '@/components/FilterTags.vue'
+import FilterTags, { type Tag } from '@/components/FilterTags.vue'
 import SelectionSummary from '@/components/SelectionSummary.vue'
 import LoadingState from '@/components/LoadingState.vue'
 import EmptyState from '@/components/EmptyState.vue'
@@ -36,7 +36,7 @@ const pendingSelection = ref<{
 
 const searchQuery = ref('')
 const sourceFilter = ref<'all' | 'official' | 'community'>('all')
-const activeTags = ref<string[]>([])
+const activeTags = ref<Tag[]>([])
 
 onMounted(() => {
   presetStore.loadPresets()
@@ -52,25 +52,25 @@ const filteredPresets = computed(() => {
       (sourceFilter.value === 'official' && p.is_official) ||
       (sourceFilter.value === 'community' && !p.is_official)
     const tagsMatch =
-      activeTags.value.length === 0 || p.tags?.some((tag) => activeTags.value.includes(tag))
+      activeTags.value.length === 0 || p.tags?.some(tag => activeTags.value.filter(t => t.value === tag).length)
 
     return nameMatch && sourceMatch && tagsMatch
   })
 })
 
 const uniqueTags = computed(() => {
-  const tags = new Set<string>()
+  const tags = new Set<Tag>()
   presetStore.presets.forEach((p) => {
-    p.tags?.forEach((tag) => tags.add(tag))
+    p.tags?.forEach(tag => tags.add({label: tag, value: tag}))
   })
-  return Array.from(tags).sort()
+  return Array.from(tags).sort((a, b) => a.value.localeCompare(b.value))
 })
 
 const selectionSummary = computed(() => presetStore.selectionSummary)
 
 // Filter management
-function toggleTag(tag: string) {
-  const index = activeTags.value.indexOf(tag)
+function toggleTag(tag: Tag) {
+  const index = activeTags.value.findIndex(c => c.value === tag.value)
   if (index === -1) {
     activeTags.value.push(tag)
   } else {

--- a/spa/src/views/PresetsList.vue
+++ b/spa/src/views/PresetsList.vue
@@ -52,18 +52,18 @@ const filteredPresets = computed(() => {
       (sourceFilter.value === 'official' && p.is_official) ||
       (sourceFilter.value === 'community' && !p.is_official)
     const tagsMatch =
-      activeTags.value.length === 0 || p.tags?.some(tag => activeTags.value.filter(t => t.value === tag).length)
+      activeTags.value.length === 0 || p.tags?.some(tag => activeTags.value.some(t => t.value === tag))
 
     return nameMatch && sourceMatch && tagsMatch
   })
 })
 
 const uniqueTags = computed(() => {
-  const tags = new Set<Tag>()
+  const tags = new Set<string>()
   presetStore.presets.forEach((p) => {
-    p.tags?.forEach(tag => tags.add({label: tag, value: tag}))
+    p.tags?.forEach(tag => tags.add(tag))
   })
-  return Array.from(tags).sort((a, b) => a.value.localeCompare(b.value))
+  return Array.from(tags).sort().map(tag => ({value: tag, label: tag}))
 })
 
 const selectionSummary = computed(() => presetStore.selectionSummary)


### PR DESCRIPTION
![Image](https://github.com/user-attachments/assets/70795cc3-4bd0-4e53-bf36-f7f0a20e2a0c)
## Проблема
Тэги из пресетов и категории из плагинов имеют разные типы, тэги это просто стринги, плагины это `{value, label}`. 
Не смотря на то, что в проекте присутствует и `PluginCategory` тип и `Tag`, они по сути не используются, вся фильтрация в компоненте `SearchAndFilters.vue` происходит исходя из того, что ему толкают строки. 

## Решение
Доделал типы исходя из текущих, навёл немного порядка. Но по хорошему надо привести PluginCategory/Tag к одному типу Tag. Так же мне не нравится, что мы прокидываем в activeCategory объект, а не `value` из объекта, но иначе придётся городить обёртку внутри `activeCategoriesLabel` в зависимости от текущего типа фильтра. Т.е. если передавать только `value` , нужно понимать `value` чего мы показываем, тэга или категории. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated category and tag handling across filters and lists to use structured objects instead of plain strings, ensuring more consistent and reliable filtering and selection.
  * Improved display of active categories and tags to show user-friendly labels.
  * Adjusted event handling to emit detailed tag and category objects, enhancing integration between components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->