### PR TITLE
feat: Make configuration generation panel sticky at bottom

### DIFF
--- a/spa/src/App.vue
+++ b/spa/src/App.vue
@@ -7,6 +7,7 @@
         <RouterView :key="$route.fullPath" />
       </div>
     </main>
+    <StickyConfiguration />
     <ContributorsSection />
     <AppFooter />
   </div>
@@ -18,6 +19,7 @@ import AppHeader from './components/AppHeader.vue'
 import AppFooter from './components/AppFooter.vue'
 import ContributorsSection from './components/contributors/ContributorsSection.vue'
 import BackgroundPattern from './components/BackgroundPattern.vue'
+import StickyConfiguration from './components/StickyConfiguration.vue'
 </script>
 
 <style scoped>

--- a/spa/src/components/ConfigurationGeneration.vue
+++ b/spa/src/components/ConfigurationGeneration.vue
@@ -1,82 +1,86 @@
 <template>
-  <div v-if="isVisible" class="configuration-generation">
-    <div class="configuration-generation__header">
-      <h3 class="configuration-generation__title">
-        {{ title }}
-      </h3>
-      <p class="configuration-generation__description">
-        {{ description }}
-      </p>
-    </div>
-    
-    <!-- Configuration Format Selector -->
-    <ConfigFormatSelector 
-      v-model="internalFormat" 
-      :disabled="disabled"
-      class="configuration-generation__format-selector" 
-    />
+  <Teleport to="#sticky-configuration">
+    <div class="configuration-generation__wrapper">
+    <div v-if="isVisible" class="configuration-generation">
+      <div class="configuration-generation__header">
+        <h3 class="configuration-generation__title">
+          {{ title }}
+        </h3>
+        <p class="configuration-generation__description">
+          {{ description }}
+        </p>
+      </div>
 
-    <!-- Additional Options Slot -->
-    <div v-if="$slots.options" class="configuration-generation__options">
-      <slot name="options"></slot>
-    </div>
+      <!-- Configuration Format Selector -->
+      <ConfigFormatSelector
+        v-model="internalFormat"
+        :disabled="disabled"
+        class="configuration-generation__format-selector"
+      />
 
-    <!-- Generate Button -->
-    <div class="configuration-generation__button-wrapper">
-      <button
-        @click="handleGenerate"
-        :disabled="disabled || isGenerating"
-        class="configuration-generation__button"
-        :class="{
-          'configuration-generation__button--loading': isGenerating,
-          'configuration-generation__button--disabled': disabled || isGenerating
-        }"
-      >
-        <span class="configuration-generation__button-content">
-          <!-- Loading Spinner -->
-          <div 
-            v-if="isGenerating"
-            class="configuration-generation__spinner"
+      <!-- Additional Options Slot -->
+      <div v-if="$slots.options" class="configuration-generation__options">
+        <slot name="options"></slot>
+      </div>
+
+      <!-- Generate Button -->
+      <div class="configuration-generation__button-wrapper">
+        <button
+          @click="handleGenerate"
+          :disabled="disabled || isGenerating"
+          class="configuration-generation__button"
+          :class="{
+            'configuration-generation__button--loading': isGenerating,
+            'configuration-generation__button--disabled': disabled || isGenerating
+          }"
+        >
+          <span class="configuration-generation__button-content">
+            <!-- Loading Spinner -->
+            <div
+              v-if="isGenerating"
+              class="configuration-generation__spinner"
+            ></div>
+            <!-- Download Icon -->
+            <svg v-else class="configuration-generation__download-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            {{ isGenerating ? 'Generating...' : buttonText }}
+          </span>
+        </button>
+      </div>
+
+      <!-- Status Messages -->
+      <div v-if="statusMessage" class="configuration-generation__status">
+        <p
+          class="configuration-generation__status-text"
+          :class="`configuration-generation__status-text--${statusType}`"
+        >
+          {{ statusMessage }}
+        </p>
+      </div>
+
+      <!-- Progress Indicator -->
+      <div v-if="showProgress && progress !== null" class="configuration-generation__progress">
+        <div class="configuration-generation__progress-bar">
+          <div
+            class="configuration-generation__progress-fill"
+            :style="{ width: `${Math.min(100, Math.max(0, progress))}%` }"
           ></div>
-          <!-- Download Icon -->
-          <svg v-else class="configuration-generation__download-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
-          {{ isGenerating ? 'Generating...' : buttonText }}
-        </span>
-      </button>
-    </div>
-
-    <!-- Status Messages -->
-    <div v-if="statusMessage" class="configuration-generation__status">
-      <p 
-        class="configuration-generation__status-text"
-        :class="`configuration-generation__status-text--${statusType}`"
-      >
-        {{ statusMessage }}
-      </p>
-    </div>
-
-    <!-- Progress Indicator -->
-    <div v-if="showProgress && progress !== null" class="configuration-generation__progress">
-      <div class="configuration-generation__progress-bar">
-        <div 
-          class="configuration-generation__progress-fill"
-          :style="{ width: `${Math.min(100, Math.max(0, progress))}%` }"
-        ></div>
+        </div>
+        <div class="configuration-generation__progress-text">
+          {{ Math.round(progress) }}% complete
+        </div>
       </div>
-      <div class="configuration-generation__progress-text">
-        {{ Math.round(progress) }}% complete
+
+      <!-- Help Text -->
+      <div v-if="helpText" class="configuration-generation__help">
+        <p class="configuration-generation__help-text">
+          {{ helpText }}
+        </p>
       </div>
     </div>
-
-    <!-- Help Text -->
-    <div v-if="helpText" class="configuration-generation__help">
-      <p class="configuration-generation__help-text">
-        {{ helpText }}
-      </p>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -144,8 +148,12 @@ function handleGenerate() {
 </script>
 
 <style scoped>
+.configuration-generation__wrapper {
+  @apply border-t border-slate-700/50 mx-auto;
+}
+
 .configuration-generation {
-  @apply pt-8 border-t border-slate-700/50;
+  @apply p-8 max-w-7xl mx-auto;
 }
 
 .configuration-generation__header {

--- a/spa/src/components/StickyConfiguration.vue
+++ b/spa/src/components/StickyConfiguration.vue
@@ -1,0 +1,14 @@
+<template>
+  <div id="sticky-configuration"></div>
+</template>
+
+<script setup lang="ts">
+// Простой портал для телепорта ConfigurationGeneration
+</script>
+
+<style scoped>
+#sticky-configuration {
+  @apply z-50 bg-gray-900/95 backdrop-blur-md;
+  @apply md:sticky md:bottom-0;
+}
+</style>


### PR DESCRIPTION
## 📌 What's Changed

Added sticky positioning for the configuration generation panel to improve UX when selecting plugins/presets.

## 🎯 Problem Solved

Previously, the configuration generation panel appeared at the bottom of the page content, requiring users to scroll down to access it after making selections. This was inconvenient, especially on long lists.

![Peek 2025-06-30 07-55](https://github.com/user-attachments/assets/d3328059-d522-4044-9d5e-f549e363288e)

## ✨ Solution

- **Sticky Panel**: Configuration panel now sticks to the bottom of the viewport
- **Smart Positioning**: Panel stops before the contributors section (doesn't overlap footer content)
- **Teleport Architecture**: Uses Vue 3 Teleport to render the panel in a dedicated portal
- **Clean Separation**: Portal component handles positioning, generation component handles functionality

## 🔧 Technical Changes

- Added `StickyConfiguration.vue` component as teleport portal
- Updated `ConfigurationGeneration.vue` to use Teleport
- Modified `App.vue` to include sticky portal above contributors section
- Maintained original styling and BEM naming conventions
- Panel only appears when items are selected (`selectionCount > 0`)

## 📱 Behavior

- ✅ Sticks to bottom during scroll
- ✅ Stops before contributors section  
- ✅ Only visible when selections are made
- ✅ Maintains all original functionality
- ✅ Responsive design preserved