### PR TITLE
feat: Implement shareable plugin and preset selection via URL query parameters

### DIFF
--- a/spa/src/stores/usePluginsStore.ts
+++ b/spa/src/stores/usePluginsStore.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 import * as pluginApi from '@/api/pluginsApi'
 import type {
   Plugin,

--- a/spa/src/stores/usePluginsStore.ts
+++ b/spa/src/stores/usePluginsStore.ts
@@ -94,12 +94,12 @@ export const usePluginsStore = defineStore('plugins', {
       // Load selections from URL on init
       this.loadSelectionsFromUrl()
       
-      // Watch URL changes, но ТОЛЬКО внешние
+      // Watch URL changes, but only external ones
       if (route && router) {
         watch(
           () => route.query.plugins,
           (newValue, oldValue) => {
-            // Игнорируем изменения если мы сами обновляем URL
+            // Ignore changes if we're updating the URL ourselves
             if (this.isUpdatingFromUrl) return
             
             console.log('🌐 External URL change detected:', { old: oldValue, new: newValue })
@@ -118,17 +118,17 @@ export const usePluginsStore = defineStore('plugins', {
       try {
         const pluginsParam = this.route.query.plugins
         
-        // Получаем новый список плагинов из URL
+        // Get new plugin list from URL
         const newPluginNames = !pluginsParam ? [] : (
           Array.isArray(pluginsParam) 
             ? pluginsParam.flatMap((p: string) => p.split(',')).filter(Boolean)
             : String(pluginsParam).split(',').filter(Boolean)
         )
         
-        // Получаем текущие manually selected плагины
+        // Get current manually selected plugins
         const currentManualPlugins = this.manuallySelectedPlugins
         
-        // Проверяем, изменился ли список (избегаем ненужных обновлений)
+        // Check if the list has changed (avoid unnecessary updates)
         const hasChanged = 
           newPluginNames.length !== currentManualPlugins.length ||
           !newPluginNames.every(name => currentManualPlugins.includes(name))
@@ -137,14 +137,14 @@ export const usePluginsStore = defineStore('plugins', {
           return
         }
         
-        // Удаляем только те manual плагины, которых нет в новом списке
+        // Remove only those manual plugins that are not in the new list
         for (const pluginName of currentManualPlugins) {
           if (!newPluginNames.includes(pluginName)) {
             this.deselectPlugin(pluginName)
           }
         }
         
-        // Добавляем новые плагины
+        // Add new plugins
         for (const name of newPluginNames) {
           if (this.plugins.some(p => p.name === name) && !currentManualPlugins.includes(name)) {
             await this.selectPlugin(name, true)
@@ -163,42 +163,42 @@ export const usePluginsStore = defineStore('plugins', {
       const manualPlugins = this.manuallySelectedPlugins
       const currentPluginsInUrl = this.route.query.plugins
       
-      // Проверяем, нужно ли обновлять URL
+      // Check if URL needs updating
       const newUrlValue = manualPlugins.length === 0 ? undefined : manualPlugins.join(',')
       const currentUrlValue = Array.isArray(currentPluginsInUrl) 
         ? currentPluginsInUrl.join(',') 
         : currentPluginsInUrl
       
-      // Если значения одинаковые, не обновляем URL
+      // If values are the same, don't update URL
       if (newUrlValue === currentUrlValue) {
         return
       }
       
-      // Отмечаем что мы обновляем URL
+      // Mark that we're updating the URL
       this.isUpdatingFromUrl = true
       
-      // Создаем новый URL с query string вручную (без энкодинга запятых)
+      // Create new URL with query string manually (without encoding commas)
       const baseUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
       const searchParams = new URLSearchParams(window.location.search)
       
-      // Удаляем plugins параметр из существующих params
+      // Remove plugins parameter from existing params
       searchParams.delete('plugins')
       
-      // Собираем финальный URL
+      // Build final URL
       let finalUrl = baseUrl
       const otherParams = searchParams.toString()
       const pluginsParam = manualPlugins.length > 0 ? `plugins=${manualPlugins.join(',')}` : ''
       
-      // Собираем query string
+      // Build query string
       const queryParts = [otherParams, pluginsParam].filter(Boolean)
       if (queryParts.length > 0) {
         finalUrl += '?' + queryParts.join('&')
       }
       
-      // Используем нативный history API вместо Vue Router
+      // Use native history API instead of Vue Router
       window.history.replaceState(null, '', finalUrl)
       
-      // Сбрасываем флаг асинхронно
+      // Reset flag asynchronously
       setTimeout(() => {
         this.isUpdatingFromUrl = false
       }, 0)
@@ -303,7 +303,7 @@ export const usePluginsStore = defineStore('plugins', {
         }
       }
       
-      // Всегда обновляем URL после изменения выбора
+      // Always update URL after changing selection
       this.updateUrl()
     },
 

--- a/spa/src/stores/usePresetsStore.ts
+++ b/spa/src/stores/usePresetsStore.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { watch } from 'vue'
 import * as presetApi from '@/api/presetsApi'
 import type { Preset, PresetQuery, GenerateConfigFromPresetsRequest } from '@/api/presetsApi'
 import type { PresetSelectionState, PresetSelectionInfo } from '@/types/preset'
@@ -15,11 +16,17 @@ export const usePresetsStore = defineStore('presets', {
     configOutput: '' as string,
     loading: false,
     error: null as string | null,
-    
+
     // Enhanced selection management
     selections: new Map<string, PresetSelectionInfo>(),
     dependencyCache: new Map<string, string[]>(), // Cache for preset plugin overlaps
     loadingDependencies: new Set<string>(),
+
+    // URL sync state
+    urlSyncEnabled: false,
+    route: null as any,
+    router: null as any,
+    isUpdatingFromUrl: false, // Prevent recursive updates
   }),
 
   getters: {
@@ -72,7 +79,7 @@ export const usePresetsStore = defineStore('presets', {
       const manual = this.manuallySelectedPresets
       const total = this.allSelectedPresets
       const dependencies = total.length - manual.length
-      
+
       // Calculate total unique plugins across all selected presets
       const allPlugins = new Set<string>()
       for (const presetName of total) {
@@ -81,7 +88,7 @@ export const usePresetsStore = defineStore('presets', {
           preset.plugins.forEach(plugin => allPlugins.add(plugin))
         }
       }
-      
+
       return {
         manual: manual.length,
         dependencies,
@@ -92,12 +99,136 @@ export const usePresetsStore = defineStore('presets', {
   },
 
   actions: {
+    // Initialize URL sync
+    initUrlSync(route: any, router: any) {
+      this.route = route
+      this.router = router
+      this.urlSyncEnabled = true
+
+      // Load selections from URL on init
+      this.loadSelectionsFromUrl()
+
+      // Watch URL changes, но ТОЛЬКО внешние
+      if (route && router) {
+        watch(
+          () => route.query.presets,
+          (newValue, oldValue) => {
+            // Игнорируем изменения если мы сами обновляем URL
+            if (this.isUpdatingFromUrl) return
+
+            console.log('🌐 External preset URL change detected:', { old: oldValue, new: newValue })
+            this.loadSelectionsFromUrl()
+          }
+        )
+      }
+    },
+
+    // Load selections from URL
+    async loadSelectionsFromUrl() {
+      if (!this.route || this.isUpdatingFromUrl) return
+
+      this.isUpdatingFromUrl = true
+
+      try {
+        const presetsParam = this.route.query.presets
+
+        // Получаем новый список пресетов из URL
+        const newPresetNames = !presetsParam ? [] : (
+          Array.isArray(presetsParam)
+            ? presetsParam.flatMap((p: string) => p.split(',')).filter(Boolean)
+            : String(presetsParam).split(',').filter(Boolean)
+        )
+
+        // Получаем текущие manually selected пресеты
+        const currentManualPresets = this.manuallySelectedPresets
+
+        // Проверяем, изменился ли список (избегаем ненужных обновлений)
+        const hasChanged =
+          newPresetNames.length !== currentManualPresets.length ||
+          !newPresetNames.every(name => currentManualPresets.includes(name))
+
+        if (!hasChanged) {
+          return
+        }
+
+        // Удаляем только те manual пресеты, которых нет в новом списке
+        for (const presetName of currentManualPresets) {
+          if (!newPresetNames.includes(presetName)) {
+            this.deselectPreset(presetName)
+          }
+        }
+
+        // Добавляем новые пресеты
+        for (const name of newPresetNames) {
+          if (this.presets.some(p => p.name === name) && !currentManualPresets.includes(name)) {
+            await this.selectPreset(name, true)
+          }
+        }
+
+      } finally {
+        this.isUpdatingFromUrl = false
+      }
+    },
+
+    // Update URL with current selections (only manual selections)
+    updateUrl() {
+      if (!this.urlSyncEnabled || !this.route) return
+
+      const manualPresets = this.manuallySelectedPresets
+      const currentPresetsInUrl = this.route.query.presets
+
+      // Проверяем, нужно ли обновлять URL
+      const newUrlValue = manualPresets.length === 0 ? undefined : manualPresets.join(',')
+      const currentUrlValue = Array.isArray(currentPresetsInUrl)
+        ? currentPresetsInUrl.join(',')
+        : currentPresetsInUrl
+
+      // Если значения одинаковые, не обновляем URL
+      if (newUrlValue === currentUrlValue) {
+        return
+      }
+
+      // Отмечаем что мы обновляем URL
+      this.isUpdatingFromUrl = true
+
+      // Создаем новый URL с query string вручную (без энкодинга запятых)
+      const baseUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
+      const searchParams = new URLSearchParams(window.location.search)
+
+      // Удаляем presets параметр из существующих params
+      searchParams.delete('presets')
+
+      // Собираем финальный URL
+      let finalUrl = baseUrl
+      const otherParams = searchParams.toString()
+      const presetsParam = manualPresets.length > 0 ? `presets=${manualPresets.join(',')}` : ''
+
+      // Собираем query string
+      const queryParts = [otherParams, presetsParam].filter(Boolean)
+      if (queryParts.length > 0) {
+        finalUrl += '?' + queryParts.join('&')
+      }
+
+      // Используем нативный history API вместо Vue Router
+      window.history.replaceState(null, '', finalUrl)
+
+      // Сбрасываем флаг асинхронно
+      setTimeout(() => {
+        this.isUpdatingFromUrl = false
+      }, 0)
+    },
+
     async loadPresets(params?: PresetQuery) {
       this.loading = true
       this.error = null
       try {
         const res = await presetApi.fetchPresets(params)
         this.presets = res.data.data
+
+        // Reload selections from URL after presets loaded
+        if (this.urlSyncEnabled) {
+          await this.loadSelectionsFromUrl()
+        }
       } catch (e: any) {
         this.error = e.message
       } finally {
@@ -133,6 +264,9 @@ export const usePresetsStore = defineStore('presets', {
           this.deselectPreset(presetName)
         }
       }
+
+      // Всегда обновляем URL после изменения выбора
+      this.updateUrl()
     },
 
     async selectPreset(presetName: string, includeDependencies = true) {
@@ -146,7 +280,7 @@ export const usePresetsStore = defineStore('presets', {
 
       if (includeDependencies) {
         try {
-          // For presets, we can analyze plugin overlaps as "dependencies"
+          // For presets, we can analyze plugin overlaps as \"dependencies\"
           await this.analyzePresetRelationships(presetName)
         } catch (e) {
           console.error('Failed to analyze preset relationships for', presetName, e)
@@ -166,12 +300,12 @@ export const usePresetsStore = defineStore('presets', {
         if (otherPreset.name === presetName) continue
 
         const overlap = this.calculatePluginOverlap(selectedPreset.plugins, otherPreset.plugins)
-        
+
         // If there's significant overlap (>50% of plugins), consider it related
         if (overlap.percentage > 0.5 && overlap.common.length > 2) {
           // Check if this preset would be complementary (adds new plugins) or conflicting
           const uniquePlugins = otherPreset.plugins.filter(p => !selectedPreset.plugins.includes(p))
-          
+
           if (uniquePlugins.length > 0) {
             relatedPresets.push(otherPreset.name)
           }
@@ -201,7 +335,7 @@ export const usePresetsStore = defineStore('presets', {
     calculatePluginOverlap(plugins1: string[], plugins2: string[]) {
       const common = plugins1.filter(p => plugins2.includes(p))
       const total = new Set([...plugins1, ...plugins2]).size
-      
+
       return {
         common,
         percentage: common.length / Math.min(plugins1.length, plugins2.length),
@@ -220,7 +354,7 @@ export const usePresetsStore = defineStore('presets', {
       for (const [tag1, tag2] of conflictingTags) {
         const has1 = preset1.tags?.some(t => t.toLowerCase().includes(tag1.toLowerCase()))
         const has2 = preset2.tags?.some(t => t.toLowerCase().includes(tag2.toLowerCase()))
-        
+
         if (has1 && has2) {
           return true
         }
@@ -238,13 +372,13 @@ export const usePresetsStore = defineStore('presets', {
 
       // Check all dependency presets to see if they're still needed
       const allSelections = Array.from(this.selections.entries())
-      
+
       for (const [depName, depInfo] of allSelections) {
         if (depInfo.state === 'dependency' && depInfo.requiredBy?.includes(presetName)) {
           // Remove this preset from the requiredBy list
           const updatedRequiredBy = depInfo.requiredBy.filter(name => name !== presetName)
           const updatedSelectedBy = depInfo.selectedBy?.filter(name => name !== presetName) || []
-          
+
           if (updatedRequiredBy.length === 0) {
             // No longer required, remove it
             this.selections.delete(depName)
@@ -268,6 +402,7 @@ export const usePresetsStore = defineStore('presets', {
     // Clear all selections
     clearAllSelections() {
       this.selections.clear()
+      this.updateUrl()
     },
 
     // Get selection info for a specific preset
@@ -289,14 +424,14 @@ export const usePresetsStore = defineStore('presets', {
     }> {
       try {
         await this.analyzePresetRelationships(presetName)
-        
+
         const relatedPresets = this.dependencyCache.get(presetName) || []
         const allToSelect = [presetName, ...relatedPresets]
-        
+
         // Find conflicts
         const selectedPreset = this.presets.find(p => p.name === presetName)
         const conflicts: string[] = []
-        
+
         if (selectedPreset) {
           for (const otherPreset of this.presets) {
             if (this.checkPresetConflict(selectedPreset, otherPreset)) {
@@ -307,11 +442,11 @@ export const usePresetsStore = defineStore('presets', {
             }
           }
         }
-        
+
         // Split into new vs existing
         const newDependencies: string[] = []
         const existingDependencies: string[] = []
-        
+
         for (const presetName of allToSelect) {
           const existing = this.selections.get(presetName)
           if (!existing || existing.state === 'none') {
@@ -373,7 +508,7 @@ export const usePresetsStore = defineStore('presets', {
       if (this.loadingDependencies.has(presetName)) return
 
       this.loadingDependencies.add(presetName)
-      
+
       try {
         await this.analyzePresetRelationships(presetName)
       } finally {

--- a/spa/src/views/PluginsList.vue
+++ b/spa/src/views/PluginsList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { usePluginsStore } from '@/stores/usePluginsStore'
 import PluginCard from '@/components/PluginCard.vue'
 import ConfigModal from '@/components/ConfigModal.vue'
@@ -15,7 +16,10 @@ import ConfigurationGeneration from '@/components/ConfigurationGeneration.vue'
 import SelectionConfirmationModal from '@/components/SelectionConfirmationModal.vue'
 import type { PluginCategory } from '@/api/pluginsApi.ts'
 
+const route = useRoute()
+const router = useRouter()
 const pluginStore = usePluginsStore()
+
 const activeCategories = ref<PluginCategory[] | Tag[]>([])
 const configFormat = ref<'toml' | 'json' | 'docker' | 'dockerfile'>('toml')
 
@@ -33,9 +37,15 @@ const pendingSelection = ref<{
   }
 } | null>(null)
 
-onMounted(() => {
-  pluginStore.loadCategories()
-  pluginStore.loadPlugins()
+onMounted(async () => {
+  // Initialize URL sync
+  pluginStore.initUrlSync(route, router)
+  
+  // Load data
+  await Promise.all([
+    pluginStore.loadCategories(),
+    pluginStore.loadPlugins()
+  ])
 })
 
 const filteredPlugins = computed(() => {

--- a/spa/src/views/PresetsList.vue
+++ b/spa/src/views/PresetsList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { usePresetsStore } from '@/stores/usePresetsStore'
 import PresetCard from '@/components/PresetCard.vue'
 import ConfigModal from '@/components/ConfigModal.vue'
@@ -14,7 +15,10 @@ import EmptyState from '@/components/EmptyState.vue'
 import ConfigurationGeneration from '@/components/ConfigurationGeneration.vue'
 import SelectionConfirmationModal from '@/components/SelectionConfirmationModal.vue'
 
+const route = useRoute()
+const router = useRouter()
 const presetStore = usePresetsStore()
+
 const configFormat = ref<'toml' | 'json' | 'docker' | 'dockerfile'>('toml')
 
 const showModal = ref(false)
@@ -38,8 +42,12 @@ const searchQuery = ref('')
 const sourceFilter = ref<'all' | 'official' | 'community'>('all')
 const activeTags = ref<Tag[]>([])
 
-onMounted(() => {
-  presetStore.loadPresets()
+onMounted(async () => {
+  // Initialize URL sync
+  presetStore.initUrlSync(route, router)
+  
+  // Load data
+  await presetStore.loadPresets()
 })
 
 const filteredPresets = computed(() => {


### PR DESCRIPTION
This PR implements issue #28 by adding support for shareable plugin and preset selection through URL query parameters.

**Changes made:**
- Enhanced `PluginList` and `PresetList` components to sync with URL parameters
- Updated `usePluginStore` and `usePresetStore` hooks to handle URL state management
- Added URL query parameter handling for `plugins` and `presets` parameters
- Implemented bidirectional sync between UI selection and URL state

**Features:**
- Users can now share plugin configurations via URL links
- Plugin and preset selections are automatically restored from URL on page load
- URL updates dynamically as users modify their selections
- Backwards compatible - works without URL parameters

**Technical details:**
- Query parameters use comma-separated plugin/preset names
- State synchronization prevents infinite update loops
- Kept `usePluginStore` and `usePresetStore` as separate hooks instead of merging them, as future preset functionality development is unclear and maintaining separation provides better flexibility for independent evolution

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin and preset selections are now synchronized with the browser URL, allowing selections to be shared or bookmarked.
  * Selections update automatically if the URL changes externally.

* **Improvements**
  * Faster loading of plugin categories and plugins through parallel data fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->